### PR TITLE
[PAN-3005] New API parameter format.

### DIFF
--- a/docs/Reference/Pantheon-API-Methods.md
+++ b/docs/Reference/Pantheon-API-Methods.md
@@ -4072,10 +4072,8 @@ Creates a privacy group containing the specified members. Members are specified 
 
 `Object` - Request options:
 
-* `addresses`: `array of data` - Array of members specified by Orion public keys 
-
+* `addresses`: `array of data` - Array of members specified by Orion public keys.
 * `name`: `string` - Privacy group name. Optional.
-
 * `description`: `string` - Privacy group description. Optional.
 
 **Returns** 

--- a/docs/Reference/Pantheon-API-Methods.md
+++ b/docs/Reference/Pantheon-API-Methods.md
@@ -4070,11 +4070,13 @@ Creates a privacy group containing the specified members. Members are specified 
 
 **Parameters**  
 
-`array of data` - Array of members specified by Orion public keys 
+`Object` - Request options:
 
-`string` - Privacy group name 
+* `array of data` - Array of members specified by Orion public keys 
 
-`string` - Privacy group description
+* `string` - Privacy group name. Optional.
+
+* `string` - Privacy group description. Optional.
 
 **Returns** 
 
@@ -4082,11 +4084,11 @@ Privacy group ID
 
 !!! example
     ```bash tab="curl HTTP request"
-    curl -X POST --data '{"jsonrpc":"2.0","method":"priv_createPrivacyGroup","params":[["negmDcN2P4ODpqn/6WkJ02zT/0w0bjhGpkZ8UP6vARk=","g59BmTeJIn7HIcnq8VQWgyh/pDbvbt2eyP0Ii60aDDw="], "Group A", "Description Group A"],"id":1}' http://127.0.0.1:8545
+    curl -X POST --data '{"jsonrpc":"2.0","method": "priv_createPrivacyGroup", "params": [{"addresses":["sTZpbQhcOfd9ZaFDnC00e/N2Ofv9p4/ZTBbEeVtXJ3E=","quhb1pQPGN1w8ZSZSyiIfncEAlVY/M/rauSyQ5wVMRE="],"name":"Group A","description":"Description Group A"}],"id":1}' http://127.0.0.1:8545
     ```
     
     ```bash tab="wscat WS request"
-    {"jsonrpc":"2.0","method":"priv_createPrivacyGroup","params":[["negmDcN2P4ODpqn/6WkJ02zT/0w0bjhGpkZ8UP6vARk=","g59BmTeJIn7HIcnq8VQWgyh/pDbvbt2eyP0Ii60aDDw="], "Group A", "Description Group A"],"id":1}
+    {"jsonrpc":"2.0","method": "priv_createPrivacyGroup", "params": [{"addresses":["sTZpbQhcOfd9ZaFDnC00e/N2Ofv9p4/ZTBbEeVtXJ3E=","quhb1pQPGN1w8ZSZSyiIfncEAlVY/M/rauSyQ5wVMRE="],"name":"Group A","description":"Description Group A"}],"id":1}
     ```
     
     ```json tab="JSON result"

--- a/docs/Reference/Pantheon-API-Methods.md
+++ b/docs/Reference/Pantheon-API-Methods.md
@@ -4072,11 +4072,11 @@ Creates a privacy group containing the specified members. Members are specified 
 
 `Object` - Request options:
 
-* `array of data` - Array of members specified by Orion public keys 
+* `addresses`: `array of data` - Array of members specified by Orion public keys 
 
-* `string` - Privacy group name. Optional.
+* `name`: `string` - Privacy group name. Optional.
 
-* `string` - Privacy group description. Optional.
+* `description`: `string` - Privacy group description. Optional.
 
 **Returns** 
 


### PR DESCRIPTION
## PR description

The parameters for `priv_createPrivacyGroup` are listed in an object. Additionally, the `name` and `description` parameters are optional.

## Fixed Issue(s)
PAN-3005
