### PR TITLE
fix community link in guide

### DIFF
--- a/MKDOCS-MARKDOWN-GUIDE.md
+++ b/MKDOCS-MARKDOWN-GUIDE.md
@@ -8,7 +8,7 @@ However, we use two flavors of this syntax:
 in the [Installed Markdown Extensions](#installed-markdown-extensions) section.
 - Another using the [Github syntax](https://guides.github.com/features/mastering-markdown/) 
 for pages outside of this documentation directory. These are mainly files to support our [open source 
-community](https://github.com/PegaSysEng/pantheon/community).
+community](https://github.com/PegaSysEng/doc.pantheon/community).
 
 ## MkDocs Documentation Website
 

--- a/link_check_conf.json
+++ b/link_check_conf.json
@@ -7,7 +7,7 @@
             "pattern": "^http(s)?://127.0.0.1"
         },
         {
-            "pattern": "^http(s)?://github.com/PegaSysEng/pantheon/community"
+            "pattern": "^http(s)?://github.com/PegaSysEng/doc.pantheon/community"
         },
         {
             "pattern": "^http(s)?://ropsten.etherscan.io/txs\\?block="


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/doc.pantheon/blob/master/CONTRIBUTING.md -->

## PR description
Fix community link in contribution guide and also matching link checker regex.
The link was pointing to pantheon community page instead of doc.pantheon page.
## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes PAN-<Jira issue number> -->
<!-- Example: "fixes PAN-1234" -->
no issue, small fix.