### PR TITLE
fix PAN-3128 truffle config provider definition

### DIFF
--- a/docs/Tutorials/Quickstarts/Private-Network-Quickstart.md
+++ b/docs/Tutorials/Quickstarts/Private-Network-Quickstart.md
@@ -344,7 +344,7 @@ module.exports = {
   networks: {
     development: {
       host: "127.0.0.1",
-      port: 8545,
+      port: 7545,
       network_id: "*" // Match any network id
     },
     quickstartWallet: {

--- a/docs/Tutorials/Quickstarts/Private-Network-Quickstart.md
+++ b/docs/Tutorials/Quickstarts/Private-Network-Quickstart.md
@@ -337,7 +337,6 @@ code with placeholders to change as directed below:
 ```javascript
 const PrivateKeyProvider = require("truffle-hdwallet-provider");
 const privateKey = "8f2a55949038a9610f50fb23b5883af3b4ecb3c3bb792cbcefbd1542c692be63";
-const privateKeyProvider = new PrivateKeyProvider(privateKey, "<YOUR HTTP RPC NODE ENDPOINT>");
 
 module.exports = {
   // See <http://truffleframework.com/docs/advanced/configuration>
@@ -345,11 +344,11 @@ module.exports = {
   networks: {
     development: {
       host: "127.0.0.1",
-      port: 7545,
+      port: 8545,
       network_id: "*" // Match any network id
     },
     quickstartWallet: {
-      provider: privateKeyProvider,
+      provider: () => new PrivateKeyProvider(privateKey, "<YOUR HTTP RPC NODE ENDPOINT>"),
       network_id: "*"
     },
   }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/doc.pantheon/blob/master/CONTRIBUTING.md -->

## PR description
use the new way to declare provider in Truffle config to prevent multithreaded tests to reach a single provider connections limit.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes PAN-<Jira issue number> -->
<!-- Example: "fixes PAN-1234" -->
fixes PAN-3128