### PR TITLE
[PAN-2392] Document JSON-RPC methods' behaviour when in fast-sync

### DIFF
--- a/docs/HowTo/Interact/Pantheon-APIs/Using-JSON-RPC-API.md
+++ b/docs/HowTo/Interact/Pantheon-APIs/Using-JSON-RPC-API.md
@@ -120,4 +120,5 @@ The block parameter can have the following values:
 * `pending` : `tag` - Last block mined plus pending transactions. Use only with [eth_getTransactionCount](../../../Reference/Pantheon-API-Methods.md#eth_gettransactioncount).  
 
 !!! note
-    Synchronizing in FAST mode means historical world state data will be unavailable.  Any methods attempting to access unavailable world state data will return `null`.
+    If [synchronizing in FAST mode](../../../Reference/Pantheon-CLI#fast-sync-options), most historical 
+    world state data is unavailable.  Any methods attempting to access unavailable world state data return `null`.

--- a/docs/HowTo/Interact/Pantheon-APIs/Using-JSON-RPC-API.md
+++ b/docs/HowTo/Interact/Pantheon-APIs/Using-JSON-RPC-API.md
@@ -119,3 +119,5 @@ The block parameter can have the following values:
 * `latest` : `tag` - Last block mined.
 * `pending` : `tag` - Last block mined plus pending transactions. Use only with [eth_getTransactionCount](../../../Reference/Pantheon-API-Methods.md#eth_gettransactioncount).  
 
+!!! note
+    When synchronizing in FAST mode, methods trying to access old world-state data will return `null`

--- a/docs/HowTo/Interact/Pantheon-APIs/Using-JSON-RPC-API.md
+++ b/docs/HowTo/Interact/Pantheon-APIs/Using-JSON-RPC-API.md
@@ -120,4 +120,4 @@ The block parameter can have the following values:
 * `pending` : `tag` - Last block mined plus pending transactions. Use only with [eth_getTransactionCount](../../../Reference/Pantheon-API-Methods.md#eth_gettransactioncount).  
 
 !!! note
-    When synchronizing in FAST mode, methods trying to access old world-state data will return `null`
+    Synchronizing in FAST mode means historical world state data will be unavailable.  Any methods attempting to access unavailable world state data will return `null`.

--- a/docs/Reference/Pantheon-CLI/Pantheon-CLI-Syntax.md
+++ b/docs/Reference/Pantheon-CLI/Pantheon-CLI-Syntax.md
@@ -1549,4 +1549,4 @@ fast-sync-min-peers=2
 Minimum number of peers required before starting fast sync. Default is 5.
 
 !!! note
-    Synchronizing in FAST mode will cause methods trying to access old world-state data to return `null`
+    Synchronizing in FAST mode means historical world state data will be unavailable. Any methods attempting to access unavailable world state data will return `null`.

--- a/docs/Reference/Pantheon-CLI/Pantheon-CLI-Syntax.md
+++ b/docs/Reference/Pantheon-CLI/Pantheon-CLI-Syntax.md
@@ -1549,4 +1549,5 @@ fast-sync-min-peers=2
 Minimum number of peers required before starting fast sync. Default is 5.
 
 !!! note
-    Synchronizing in FAST mode means historical world state data will be unavailable. Any methods attempting to access unavailable world state data will return `null`.
+    If synchronizing in FAST mode, most historical world state data is unavailable.  Any methods attempting 
+    to access unavailable world state data return `null`.

--- a/docs/Reference/Pantheon-CLI/Pantheon-CLI-Syntax.md
+++ b/docs/Reference/Pantheon-CLI/Pantheon-CLI-Syntax.md
@@ -1547,3 +1547,6 @@ fast-sync-min-peers=2
 ```
 
 Minimum number of peers required before starting fast sync. Default is 5.
+
+!!! note
+    Synchronizing in FAST mode will cause methods trying to access old world-state data to return `null`


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/doc.pantheon/blob/master/CONTRIBUTING.md -->

## PR description
Document the fact that JSON-RPC will return `null` when in fast-sync mode.
## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes PAN-<Jira issue number> -->
<!-- Example: "fixes PAN-1234" -->
fixes PAN-2392